### PR TITLE
Fix argument count in hook call

### DIFF
--- a/src/components/saved-content/SavedContentView.tsx
+++ b/src/components/saved-content/SavedContentView.tsx
@@ -78,8 +78,7 @@ export const SavedContentView: React.FC = () => {
     forceRefresh,
     invalidateCache,
     authReady,
-    user,
-    toast
+    user
   );
 
   // Update stable content when content changes

--- a/src/hooks/saved-content/useInitialContentLoad.ts
+++ b/src/hooks/saved-content/useInitialContentLoad.ts
@@ -1,6 +1,6 @@
 
 import { useEffect } from "react";
-import { toast } from "@/hooks/use-toast"; // Utilisation directe de toast
+import { toast } from "../toast/toast"; // Utilisation directe de toast
 
 /**
  * Hook for handling initial content loading


### PR DESCRIPTION
The `useInitialContentLoad` hook was called with an incorrect number of arguments in `SavedContentView.tsx`. This commit corrects the number of arguments passed to the hook to match its expected signature.